### PR TITLE
Cambios para generar .hex en los tests y creación de un directorio para simulación con Icarus Verilog

### DIFF
--- a/sim/tests/Icarus_simulation/checker_util.v
+++ b/sim/tests/Icarus_simulation/checker_util.v
@@ -1,0 +1,78 @@
+`timescale 1ns/1ps
+`include "testbench_h.v"
+
+module edges(
+    input clock,
+    input reset,
+    input signal,
+    output fell,
+    output rose,
+    output changed
+);
+wire signal_past;
+past u_signal_past(
+    .clock(clock),
+    .reset(reset),
+    .signal(signal),
+    .signal_past(signal_past)
+);
+assign fell = signal_past && !signal;
+assign rose = !signal_past && signal;
+assign changed = signal_past != signal;
+endmodule
+
+module past #(
+    parameter width = 1
+)(
+    input clock,
+    input reset,
+    input [width-1:0] signal,
+    output [width-1:0] signal_past
+);
+reg [width-1:0] signal_past;
+always @(posedge clock)
+    if(!reset)
+        signal_past <= 0;
+    else
+        signal_past <= signal;
+endmodule
+
+module flag #(
+    parameter async_up = `FALSE,
+    parameter async_down = `FALSE
+)(
+    input clock,
+    input reset,
+    input up,
+    input down,
+    output flag,
+    output flag_rose,
+    output flag_fell,
+    output flag_changed
+);
+reg flag_reg;
+reg flag;
+always @(*) begin
+    flag = flag_reg;
+    if(async_up == `TRUE)
+        flag = flag || up;
+    if(async_down == `TRUE)
+        flag = flag && !down;
+end
+always @(posedge clock)
+    if(!reset)
+        flag_reg <= 0;
+    else if(up)
+        flag_reg <= 1;
+    else if(down)
+        flag_reg <= 0;
+edges flag_edges (
+    .clock(clock),
+    .reset(reset),
+    .signal(flag),
+    .fell(flag_fell),
+    .rose(flag_rose),
+    .changed(flag_changed)
+);
+endmodule
+

--- a/sim/tests/Icarus_simulation/control_unit.v
+++ b/sim/tests/Icarus_simulation/control_unit.v
@@ -1,0 +1,236 @@
+`timescale 1ns/1ps
+`include "copperv_h.v"
+
+module control_unit ( 
+    input clk,
+    input rst,
+    input [`INST_TYPE_WIDTH-1:0] inst_type,
+    input inst_valid,
+    input [`ALU_COMP_WIDTH-1:0] alu_comp,
+    input [`FUNCT_WIDTH-1:0] funct,
+    input data_valid,
+    output reg inst_fetch,
+    output reg load_data,
+    output reg store_data,
+    output reg rd_en,
+    output reg rs1_en,
+    output reg rs2_en,
+    output reg [`RD_DIN_SEL_WIDTH-1:0] rd_din_sel,
+    output reg [`PC_NEXT_SEL_WIDTH-1:0] pc_next_sel,
+    output reg [`ALU_DIN1_SEL_WIDTH-1:0] alu_din1_sel,
+    output reg [`ALU_DIN2_SEL_WIDTH-1:0] alu_din2_sel,
+    output reg [`ALU_OP_WIDTH-1:0] alu_op
+);
+reg [`STATE_WIDTH-1:0] state;
+reg [`STATE_WIDTH-1:0] state_next;
+reg state_change;
+reg take_branch;
+wire state_change_next;
+always @(posedge clk) begin
+    if(!rst)
+        state <= `STATE_RESET;
+    else
+        state <= state_next;
+end
+assign state_change_next = state != state_next;
+// TODO: gate possible?
+always @(posedge clk) begin
+    state_change <= state_change_next;
+end
+// Next state logic
+always @(*) begin
+    state_next = `STATE_RESET;
+    case (state)
+        `STATE_RESET: begin
+            state_next = `STATE_FETCH;
+        end
+        `STATE_FETCH: begin
+            if (inst_valid)
+                case(inst_type)
+                    `INST_TYPE_JAL:   state_next = `STATE_EXEC;
+                    default:          state_next = `STATE_DECODE;
+                endcase
+            else
+                state_next = `STATE_FETCH;
+        end
+        `STATE_DECODE: begin
+            case (inst_type)
+                `INST_TYPE_IMM:   state_next = `STATE_FETCH;
+                `INST_TYPE_FENCE: state_next = `STATE_FETCH;
+                default:          state_next = `STATE_EXEC;
+            endcase
+        end
+        `STATE_EXEC: begin
+            case (inst_type)
+                `INST_TYPE_STORE: state_next = `STATE_MEM;
+                `INST_TYPE_LOAD:  state_next = `STATE_MEM;
+                default: state_next = `STATE_FETCH;
+            endcase
+        end
+        `STATE_MEM: begin
+            if (data_valid)
+                state_next = `STATE_FETCH;
+            else
+                state_next = `STATE_MEM;
+        end
+    endcase
+end
+// Output logic
+always @(*) begin
+    inst_fetch = 0;
+    rd_en = 0;
+    rs1_en = 0;
+    rs2_en = 0;
+    rd_din_sel = 0;
+    alu_din1_sel = 0;
+    alu_din2_sel = 0;
+    pc_next_sel = `PC_NEXT_SEL_STALL;
+    alu_op = `ALU_OP_NOP;
+    load_data = 0;
+    take_branch = 0;
+    store_data = 0;
+    case (state)
+        `STATE_FETCH: begin
+            inst_fetch = state_change;
+        end
+        `STATE_DECODE: begin
+            case (inst_type)
+                `INST_TYPE_IMM: begin
+                    rd_en = 1;
+                    rd_din_sel = `RD_DIN_SEL_IMM;
+                    pc_next_sel = `PC_NEXT_SEL_INCR;
+                end
+                `INST_TYPE_INT_IMM: begin
+                    rs1_en = 1;
+                end
+                `INST_TYPE_INT_REG: begin
+                    rs1_en = 1;
+                    rs2_en = 1;
+                end
+                `INST_TYPE_BRANCH: begin
+                    rs1_en = 1;
+                    rs2_en = 1;
+                end
+                `INST_TYPE_STORE: begin
+                    rs1_en = 1;
+                    rs2_en = 1;
+                end
+                `INST_TYPE_LOAD: begin
+                    rs1_en = 1;
+                end
+                `INST_TYPE_JALR: begin
+                    rs1_en = 1;
+                end
+                `INST_TYPE_FENCE: begin
+                    pc_next_sel = `PC_NEXT_SEL_INCR;
+                end
+            endcase
+        end
+        `STATE_EXEC: begin
+            case (inst_type)
+                `INST_TYPE_INT_IMM: begin
+                    rd_en = 1;
+                    rd_din_sel = `RD_DIN_SEL_ALU;
+                    alu_din1_sel = `ALU_DIN1_SEL_RS1;
+                    alu_din2_sel = `ALU_DIN2_SEL_IMM;
+                    pc_next_sel = `PC_NEXT_SEL_INCR;
+                    alu_op = get_int_alu_op(funct);
+                end
+                `INST_TYPE_INT_REG: begin
+                    rd_en = 1;
+                    rd_din_sel = `RD_DIN_SEL_ALU;
+                    alu_din1_sel = `ALU_DIN1_SEL_RS1;
+                    alu_din2_sel = `ALU_DIN2_SEL_RS2;
+                    pc_next_sel = `PC_NEXT_SEL_INCR;
+                    alu_op = get_int_alu_op(funct);
+                end
+                `INST_TYPE_BRANCH: begin
+                    alu_din1_sel = `ALU_DIN1_SEL_RS1;
+                    alu_din2_sel = `ALU_DIN2_SEL_RS2;
+                    case(funct)
+                        `FUNCT_EQ:
+                            take_branch =  alu_comp[`ALU_COMP_EQ];
+                        `FUNCT_NEQ:
+                            take_branch = !alu_comp[`ALU_COMP_EQ];
+                        `FUNCT_LT:
+                            take_branch =  alu_comp[`ALU_COMP_LT];
+                        `FUNCT_GTE:
+                            take_branch = !alu_comp[`ALU_COMP_LT];
+                        `FUNCT_LTU:
+                            take_branch =  alu_comp[`ALU_COMP_LTU];
+                        `FUNCT_GTEU:
+                            take_branch = !alu_comp[`ALU_COMP_LTU];
+                    endcase
+                    if(take_branch)
+                        pc_next_sel = `PC_NEXT_SEL_ADD_IMM;
+                    else
+                        pc_next_sel = `PC_NEXT_SEL_INCR;
+                end
+                `INST_TYPE_STORE: begin
+                    alu_din1_sel = `ALU_DIN1_SEL_RS1;
+                    alu_din2_sel = `ALU_DIN2_SEL_IMM;
+                    alu_op = `ALU_OP_ADD;
+                    store_data = state_change;
+                end
+                `INST_TYPE_LOAD: begin
+                    alu_din1_sel = `ALU_DIN1_SEL_RS1;
+                    alu_din2_sel = `ALU_DIN2_SEL_IMM;
+                    alu_op = `ALU_OP_ADD;
+                    load_data = state_change;
+                end
+                `INST_TYPE_JAL: begin
+                    rd_en = 1;
+                    rd_din_sel = `RD_DIN_SEL_ALU;
+                    alu_din1_sel = `ALU_DIN1_SEL_PC;
+                    alu_din2_sel = `ALU_DIN2_SEL_CONST_4;
+                    pc_next_sel = `PC_NEXT_SEL_ADD_IMM;
+                    alu_op = `ALU_OP_ADD;
+                end
+                `INST_TYPE_AUIPC: begin
+                    rd_en = 1;
+                    rd_din_sel = `RD_DIN_SEL_ALU;
+                    alu_din1_sel = `ALU_DIN1_SEL_PC;
+                    alu_din2_sel = `ALU_DIN2_SEL_IMM;
+                    pc_next_sel = `PC_NEXT_SEL_INCR;
+                    alu_op = `ALU_OP_ADD;
+                end
+                `INST_TYPE_JALR: begin
+                    rd_en = 1;
+                    rd_din_sel = `RD_DIN_SEL_ALU;
+                    alu_din1_sel = `ALU_DIN1_SEL_PC;
+                    alu_din2_sel = `ALU_DIN2_SEL_CONST_4;
+                    pc_next_sel = `PC_NEXT_SEL_ADD_RS1_IMM;
+                    alu_op = `ALU_OP_ADD;
+                end
+            endcase
+        end
+        `STATE_MEM: begin
+            alu_op = `ALU_OP_ADD;
+            if(inst_type == `INST_TYPE_LOAD) begin
+                rd_en = state_change_next;
+                rd_din_sel = `RD_DIN_SEL_MEM;
+            end
+            if(state_change_next)
+                pc_next_sel = `PC_NEXT_SEL_INCR;
+        end
+    endcase
+end
+function [`ALU_OP_WIDTH-1:0] get_int_alu_op;
+    input [`FUNCT_WIDTH-1:0] funct_t;
+    begin
+        case(funct_t)
+            `FUNCT_ADD:  get_int_alu_op = `ALU_OP_ADD;
+            `FUNCT_SUB:  get_int_alu_op = `ALU_OP_SUB;
+            `FUNCT_SLL:  get_int_alu_op = `ALU_OP_SLL;
+            `FUNCT_SLT:  get_int_alu_op = `ALU_OP_SLT;
+            `FUNCT_SLTU: get_int_alu_op = `ALU_OP_SLTU;
+            `FUNCT_XOR:  get_int_alu_op = `ALU_OP_XOR;
+            `FUNCT_SRL:  get_int_alu_op = `ALU_OP_SRL;
+            `FUNCT_SRA:  get_int_alu_op = `ALU_OP_SRA;
+            `FUNCT_OR:   get_int_alu_op = `ALU_OP_OR;
+            `FUNCT_AND:  get_int_alu_op = `ALU_OP_AND;
+            default:     get_int_alu_op = `ALU_OP_NOP;
+        endcase
+    end
+endfunction
+endmodule

--- a/sim/tests/Icarus_simulation/copperv.v
+++ b/sim/tests/Icarus_simulation/copperv.v
@@ -1,0 +1,290 @@
+`timescale 1ns/1ps
+`include "copperv_h.v"
+
+module copperv (
+    input clk,
+    input rst,
+    input ir_data_valid,
+    input ir_addr_ready,
+    input [`BUS_WIDTH-1:0] ir_data,
+    input dr_data_valid,
+    input dr_addr_ready,
+    input dw_data_addr_ready,
+    input dw_resp_valid,
+    input [`BUS_WIDTH-1:0] dr_data,
+    input [`BUS_RESP_WIDTH-1:0] dw_resp,
+    output reg ir_data_ready,
+    output ir_addr_valid,
+    output [`BUS_WIDTH-1:0] ir_addr,
+    output reg dr_data_ready,
+    output reg dr_addr_valid,
+    output reg dw_data_addr_valid,
+    output reg dw_resp_ready,
+    output reg [`BUS_WIDTH-1:0] dr_addr,
+    output reg [`BUS_WIDTH-1:0] dw_data,
+    output reg [`BUS_WIDTH-1:0] dw_addr,
+    output reg [(`BUS_WIDTH/8)-1:0] dw_strobe
+);
+// idecoder begin
+wire [`IMM_WIDTH-1:0] imm;
+wire [`FUNCT_WIDTH-1:0] funct;
+wire [`ALU_OP_WIDTH-1:0] alu_op;
+wire [`REG_WIDTH-1:0] rd;
+wire [`REG_WIDTH-1:0] rs1;
+wire [`REG_WIDTH-1:0] rs2;
+wire [`INST_TYPE_WIDTH-1:0] inst_type;
+// idecoder end
+// register_file begin
+wire rd_en;
+wire rs1_en;
+wire rs2_en;
+reg [`DATA_WIDTH-1:0] rd_din;
+wire [`DATA_WIDTH-1:0] rs1_dout;
+wire [`DATA_WIDTH-1:0] rs2_dout;
+// register_file end
+// arith_logic_unit begin
+reg [`DATA_WIDTH-1:0] alu_din1;
+reg [`DATA_WIDTH-1:0] alu_din2;
+wire [`DATA_WIDTH-1:0] alu_dout;
+wire [`ALU_COMP_WIDTH-1:0] alu_comp;
+// arith_logic_unit end
+// datapath begin
+wire inst_fetch;
+reg pc_en;
+reg [`PC_WIDTH-1:0] pc;
+reg [`PC_WIDTH-1:0] pc_next;
+reg [`INST_WIDTH-1:0] inst;
+reg inst_valid;
+wire i_rdata_tran;
+wire [`RD_DIN_SEL_WIDTH-1:0] rd_din_sel;
+wire [`PC_NEXT_SEL_WIDTH-1:0] pc_next_sel;
+wire [`ALU_DIN1_SEL_WIDTH-1:0] alu_din1_sel;
+wire [`ALU_DIN2_SEL_WIDTH-1:0] alu_din2_sel;
+wire store_data;
+wire load_data;
+wire [`DATA_WIDTH-1:0] write_addr;
+reg [`DATA_WIDTH-1:0] write_data;
+reg [`DATA_WIDTH-1:0] read_data;
+reg [`DATA_WIDTH-1:0] ext_read_data;
+reg [`DATA_WIDTH-1:0] read_data_t;
+reg write_valid;
+wire dw_resp_tran;
+wire dw_data_addr_tran;
+wire dr_addr_tran;
+reg read_valid;
+wire [`BUS_WIDTH-1:0] read_addr;
+reg [2-1:0] write_offset;
+reg [2-1:0] read_offset;
+wire dr_data_tran;
+reg [(`BUS_WIDTH/8)-1:0] write_strobe;
+// datapath end
+always @(posedge clk) begin
+    if (!rst) begin
+        pc <= `PC_INIT;
+    end else if(pc_en) begin
+        pc <= pc_next;
+    end
+end
+assign ir_addr_valid = inst_fetch;
+assign ir_addr = pc;
+assign i_rdata_tran = ir_data_valid && ir_data_ready;
+always @(posedge clk) begin
+    if(!rst) begin
+        inst <= 0;
+        inst_valid <= 0;
+    end else if(i_rdata_tran) begin
+        inst <= ir_data;
+        inst_valid <= 1;
+    end else begin
+        inst_valid <= 0;
+    end
+end
+// Write response
+assign dw_resp_tran = dw_resp_valid && dw_resp_ready;
+always @(posedge clk) begin
+    if(!rst) begin
+        write_valid <= 0;
+    end else if(dw_resp_tran) begin
+        case(dw_resp)
+            `DATA_WRITE_RESP_FAIL: write_valid <= 0;
+            `DATA_WRITE_RESP_OK: write_valid <= 1;
+        endcase
+    end else
+        write_valid <= 0;
+end
+always @(posedge clk)
+    if(!rst) begin
+        ir_data_ready <= 1;
+    end
+// Write data address
+assign write_addr = alu_dout;
+assign dw_data_addr_tran = store_data && dw_data_addr_ready;
+always @(posedge clk) begin
+    if(!rst) begin
+        dw_addr <= 0;
+        dw_data <= 0;
+        dw_strobe <= 0;
+        dw_data_addr_valid <= 0;
+    end else if(dw_data_addr_tran) begin
+        dw_addr <= {write_addr[`DATA_WIDTH-1:2],2'b0};
+        dw_data <= write_data;
+        dw_strobe <= write_strobe;
+        dw_data_addr_valid <= 1;
+    end else
+        dw_data_addr_valid <= 0;
+end
+always @(posedge clk)
+    if(!rst) begin
+        dw_resp_ready <= 1;
+    end
+// Read address
+assign read_addr = alu_dout;
+assign dr_addr_tran = load_data && dr_addr_ready;
+always @(posedge clk) begin
+    if(load_data)
+        read_offset <= read_addr[1:0];
+end
+always @(posedge clk) begin
+    if(!rst) begin
+        dr_addr <= 0;
+        dr_addr_valid <= 0;
+    end else if(dr_addr_tran) begin
+        dr_addr <= {read_addr[`DATA_WIDTH-1:2],2'b0};
+        dr_addr_valid <= 1;
+    end else
+        dr_addr_valid <= 0;
+end
+// Read data
+assign dr_data_tran = dr_data_valid && dr_data_ready;
+always @(posedge clk) begin
+    if(!rst) begin
+        read_data <= 0;
+        read_valid <= 0;
+    end else if(dr_data_tran) begin
+        read_data <= dr_data;
+        read_valid <= 1;
+    end else begin
+        read_valid <= 0;
+    end
+end
+always @(posedge clk) begin
+    if(!rst) begin
+        dr_data_ready <= 1;
+    end
+end
+always @(*) begin
+    write_offset = write_addr[1:0];
+    case(funct)
+        `FUNCT_MEM_BYTE: begin
+            write_strobe = 4'b0001 << write_offset;
+            write_data   = `UNSIGNED(rs2_dout,32,7,0) << {write_offset, 3'b0};
+        end
+        `FUNCT_MEM_HWORD: begin
+            write_strobe = 4'b0011 << write_offset;
+            write_data   = `UNSIGNED(rs2_dout,32,15,0) << {write_offset, 3'b0};
+        end
+        `FUNCT_MEM_WORD: begin
+            write_strobe = 4'b1111;
+            write_data   = rs2_dout;
+        end
+        default: begin
+            write_strobe = 0;
+            write_data   = {`DATA_WIDTH{1'bX}};
+        end
+    endcase
+end
+always @(*) begin
+    read_data_t = read_data >> {read_offset, 3'b0};
+    case(funct)
+        `FUNCT_MEM_BYTE:   ext_read_data = `SIGNED(read_data_t,32,7,0);
+        `FUNCT_MEM_HWORD:  ext_read_data = `SIGNED(read_data_t,32,15,0);
+        `FUNCT_MEM_WORD:   ext_read_data = read_data_t;
+        `FUNCT_MEM_BYTEU:  ext_read_data = `UNSIGNED(read_data_t,32,7,0);
+        `FUNCT_MEM_HWORDU: ext_read_data = `UNSIGNED(read_data_t,32,15,0);
+        default:           ext_read_data = {`DATA_WIDTH{1'bX}};
+    endcase
+end
+always @(*) begin
+    rd_din = 0;
+    case(rd_din_sel)
+        `RD_DIN_SEL_IMM: rd_din = imm;
+        `RD_DIN_SEL_ALU: rd_din = alu_dout;
+        `RD_DIN_SEL_MEM: rd_din = ext_read_data;
+    endcase
+end
+always @(*) begin
+    alu_din1 = 0;
+    case (alu_din1_sel)
+        `ALU_DIN1_SEL_RS1: alu_din1 = rs1_dout;
+        `ALU_DIN1_SEL_PC:  alu_din1 = pc;
+    endcase
+end
+always @(*) begin
+    alu_din2 = 0;
+    case (alu_din2_sel)
+        `ALU_DIN2_SEL_RS2:     alu_din2 = rs2_dout;
+        `ALU_DIN2_SEL_IMM:     alu_din2 = imm;
+        `ALU_DIN2_SEL_CONST_4: alu_din2 = 4;
+    endcase
+end
+always @(*) begin
+    pc_next = 0;
+    pc_en = 1;
+    case (pc_next_sel)
+        `PC_NEXT_SEL_STALL:       pc_en = 0;
+        `PC_NEXT_SEL_INCR:        pc_next = pc + 4;
+        `PC_NEXT_SEL_ADD_IMM:     pc_next = pc + imm;
+        `PC_NEXT_SEL_ADD_RS1_IMM: pc_next = rs1_dout + imm;
+    endcase
+end
+idecoder idec (
+    .inst(inst),
+    .imm(imm),
+    .inst_type(inst_type),
+    .rd(rd),
+    .rs1(rs1),
+    .rs2(rs2),
+    .funct(funct)
+);
+register_file regfile (
+    .clk(clk),
+    .rst(rst),
+    .rd_en(rd_en),
+    .rs1_en(rs1_en),
+    .rs2_en(rs2_en),
+    .rd(rd),
+    .rs1(rs1),
+    .rs2(rs2),
+    .rd_din(rd_din),
+    .rs1_dout(rs1_dout),
+    .rs2_dout(rs2_dout)
+);
+arith_logic_unit alu (
+    .alu_din1(alu_din1),
+    .alu_din2(alu_din2),
+    .alu_op(alu_op),
+    .alu_dout(alu_dout),
+    .alu_comp(alu_comp)
+);
+control_unit control (
+    .clk(clk),
+    .rst(rst),
+    .data_valid(write_valid || read_valid),
+    .inst_valid(inst_valid),
+    .alu_comp(alu_comp),
+    .funct(funct),
+    .inst_type(inst_type),
+    .inst_fetch(inst_fetch),
+    .rd_en(rd_en),
+    .rs1_en(rs1_en),
+    .rs2_en(rs2_en),
+    .rd_din_sel(rd_din_sel),
+    .pc_next_sel(pc_next_sel),
+    .alu_din1_sel(alu_din1_sel),
+    .alu_din2_sel(alu_din2_sel),
+    .alu_op(alu_op),
+    .store_data(store_data),
+    .load_data(load_data)
+);
+endmodule
+

--- a/sim/tests/Icarus_simulation/copperv_h.v
+++ b/sim/tests/Icarus_simulation/copperv_h.v
@@ -1,0 +1,114 @@
+`ifdef __ICARUS__
+`default_nettype none
+`endif
+
+`define SIGNED(x,wlhs,high,low)   {{(wlhs-(high-low+1)){x[high]}},x[high:low]}
+`define UNSIGNED(x,wlhs,high,low) {{(wlhs-(high-low+1)){1'b0}},x[high:low]}
+
+// datapath
+`define PC_INIT                 32'h0
+`define DATA_WIDTH              32
+`define PC_WIDTH                32
+`define BUS_WIDTH               32
+`define BUS_RESP_WIDTH          1
+`define RD_DIN_SEL_WIDTH        2
+`define RD_DIN_SEL_IMM          0
+`define RD_DIN_SEL_ALU          1
+`define RD_DIN_SEL_MEM          2
+`define PC_NEXT_SEL_WIDTH       2
+`define PC_NEXT_SEL_STALL       0
+`define PC_NEXT_SEL_INCR        1
+`define PC_NEXT_SEL_ADD_IMM     2
+`define PC_NEXT_SEL_ADD_RS1_IMM 3
+`define ALU_DIN1_SEL_WIDTH      2
+`define ALU_DIN1_SEL_RS1        1
+`define ALU_DIN1_SEL_PC         2
+`define ALU_DIN2_SEL_WIDTH      2
+`define ALU_DIN2_SEL_IMM        1
+`define ALU_DIN2_SEL_RS2        2
+`define ALU_DIN2_SEL_CONST_4    3
+`define DATA_WRITE_RESP_FAIL    0
+`define DATA_WRITE_RESP_OK      1
+
+// regfile
+`define REG_WIDTH          5
+`define REG_T3             28
+
+// alu
+`define ALU_SHIFT_DIN2_WIDTH 5
+`define ALU_OP_WIDTH         4
+`define ALU_OP_NOP           0
+`define ALU_OP_ADD           1
+`define ALU_OP_SUB           2
+`define ALU_OP_AND           3
+`define ALU_OP_SLL           4
+`define ALU_OP_SRA           5
+`define ALU_OP_SRL           6
+`define ALU_OP_XOR           7
+`define ALU_OP_OR            8
+`define ALU_OP_SLT           9
+`define ALU_OP_SLTU          10
+`define ALU_COMP_WIDTH       3
+`define ALU_COMP_EQ          0
+`define ALU_COMP_LT          1
+`define ALU_COMP_LTU         2
+
+// idecoder
+`define INST_WIDTH         32
+`define IMM_WIDTH          32
+`define INST_TYPE_WIDTH    4
+`define INST_TYPE_IMM      0
+`define INST_TYPE_INT_IMM  1
+`define INST_TYPE_INT_REG  2
+`define INST_TYPE_BRANCH   3
+`define INST_TYPE_STORE    4
+`define INST_TYPE_JAL      5
+`define INST_TYPE_AUIPC    6
+`define INST_TYPE_JALR     7
+`define INST_TYPE_LOAD     8
+`define INST_TYPE_FENCE    9
+`define FUNCT_WIDTH        5
+`define FUNCT_ADD          0
+`define FUNCT_SUB          1
+`define FUNCT_AND          2
+`define FUNCT_EQ           3
+`define FUNCT_NEQ          4
+`define FUNCT_LT           5
+`define FUNCT_GTE          6
+`define FUNCT_LTU          7
+`define FUNCT_GTEU         8
+`define FUNCT_MEM_BYTE     9
+`define FUNCT_MEM_HWORD    10
+`define FUNCT_MEM_WORD     11
+`define FUNCT_MEM_BYTEU    12
+`define FUNCT_MEM_HWORDU   13
+`define FUNCT_JAL          14
+`define FUNCT_SLL          15
+`define FUNCT_SLT          16
+`define FUNCT_SLTU         17
+`define FUNCT_XOR          18
+`define FUNCT_SRL          19
+`define FUNCT_SRA          20
+`define FUNCT_OR           21
+`define OPCODE_WIDTH       7
+`define OPCODE_LOAD        {5'h00, 2'b11}
+`define OPCODE_FENCE       {5'h03, 2'b11}
+`define OPCODE_INT_IMM     {5'h04, 2'b11}
+`define OPCODE_AUIPC       {5'h05, 2'b11}
+`define OPCODE_STORE       {5'h08, 2'b11}
+`define OPCODE_INT_REG     {5'h0C, 2'b11}
+`define OPCODE_LUI         {5'h0D, 2'b11}
+`define OPCODE_BRANCH      {5'h18, 2'b11}
+`define OPCODE_JALR        {5'h19, 2'b11}
+`define OPCODE_JAL         {5'h1B, 2'b11}
+`define FUNCT3_WIDTH       3
+`define FUNCT7_WIDTH       7
+
+// control_unit
+`define STATE_WIDTH        3
+`define STATE_RESET        0
+`define STATE_IDLE         1
+`define STATE_FETCH        2
+`define STATE_DECODE       3
+`define STATE_EXEC         4
+`define STATE_MEM          5

--- a/sim/tests/Icarus_simulation/execution.v
+++ b/sim/tests/Icarus_simulation/execution.v
@@ -1,0 +1,33 @@
+`timescale 1ns/1ps
+`include "copperv_h.v"
+
+module arith_logic_unit (
+    input [`DATA_WIDTH-1:0] alu_din1,
+    input [`DATA_WIDTH-1:0] alu_din2,
+    input [`ALU_OP_WIDTH-1:0] alu_op,
+    output reg [`DATA_WIDTH-1:0] alu_dout,
+    output reg [`ALU_COMP_WIDTH-1:0] alu_comp
+);
+always @(*) begin
+    alu_dout = 0;
+    case (alu_op)
+        `ALU_OP_NOP:  alu_dout = {`DATA_WIDTH{1'bx}};
+        `ALU_OP_ADD:  alu_dout = alu_din1 + alu_din2; 
+        `ALU_OP_SUB:  alu_dout = alu_din1 - alu_din2;
+        `ALU_OP_AND:  alu_dout = alu_din1 & alu_din2;
+        `ALU_OP_SLL:  alu_dout = alu_din1 << alu_din2[`ALU_SHIFT_DIN2_WIDTH-1:0];
+        `ALU_OP_SRL:  alu_dout = alu_din1 >> alu_din2[`ALU_SHIFT_DIN2_WIDTH-1:0];
+        `ALU_OP_SRA:  alu_dout = $signed(alu_din1) >>> alu_din2[`ALU_SHIFT_DIN2_WIDTH-1:0];
+        `ALU_OP_XOR:  alu_dout = alu_din1 ^ alu_din2;
+        `ALU_OP_OR:   alu_dout = alu_din1 | alu_din2;
+        `ALU_OP_SLT:  alu_dout = `UNSIGNED(alu_comp,32,`ALU_COMP_LT,`ALU_COMP_LT);
+        `ALU_OP_SLTU: alu_dout = `UNSIGNED(alu_comp,32,`ALU_COMP_LTU,`ALU_COMP_LTU);
+    endcase
+end
+always @(*) begin
+    alu_comp[`ALU_COMP_EQ]  = alu_din1 == alu_din2;
+    alu_comp[`ALU_COMP_LT]  = $signed(alu_din1) < $signed(alu_din2);
+    alu_comp[`ALU_COMP_LTU] = alu_din1 < alu_din2;
+end
+endmodule
+

--- a/sim/tests/Icarus_simulation/fake_memory.v
+++ b/sim/tests/Icarus_simulation/fake_memory.v
@@ -1,0 +1,204 @@
+`timescale 1ns/1ps
+`include "testbench_h.v"
+`include "copperv_h.v"
+
+module sim_crossbar(
+    input clk,
+    input rst,
+    input dr_data_ready,
+    input dr_addr_valid,
+    input dw_data_addr_valid,
+    input dw_resp_ready,
+    input [`BUS_WIDTH-1:0] dr_addr,
+    input [`BUS_WIDTH-1:0] dw_data,
+    input [`BUS_WIDTH-1:0] dw_addr,
+    input [(`BUS_WIDTH/8)-1:0] dw_strobe,
+    input ir_data_ready,
+    input ir_addr_valid,
+    input [`BUS_WIDTH-1:0] ir_addr,
+    output reg dr_data_valid,
+    output dr_addr_ready,
+    output dw_data_addr_ready,
+    output reg dw_resp_valid,
+    output reg [`BUS_WIDTH-1:0] dr_data,
+    output reg ir_data_valid,
+    output ir_addr_ready,
+    output reg [`BUS_WIDTH-1:0] ir_data,
+    output reg [`BUS_RESP_WIDTH-1:0] dw_resp
+);
+// fake_memory inputs
+wire r_addr_valid;
+wire r_data_ready;
+wire w_data_addr_valid;
+wire w_resp_ready;
+wire [`BUS_WIDTH-1:0] r_addr;
+wire [`BUS_WIDTH-1:0] w_data;
+wire [`BUS_WIDTH-1:0] w_addr;
+assign r_addr_valid = ir_addr_valid | dr_addr_valid;
+assign r_data_ready = ir_data_ready | dr_data_ready;
+assign w_data_addr_valid = dw_data_addr_valid;
+assign w_resp_ready = dw_resp_ready;
+assign r_addr = ir_addr_valid ? ir_addr : dr_addr;
+assign w_data = dw_data;
+assign w_addr = dw_addr;
+// fake_memory outputs
+wire w_resp_valid;
+wire [`BUS_RESP_WIDTH-1:0] w_resp;
+wire r_addr_ready;
+wire r_data_valid;
+wire w_data_addr_ready;
+wire [`BUS_WIDTH-1:0] r_data;
+
+reg ir_addr_tran;
+always @(posedge clk) begin
+    if(!rst) begin
+        ir_addr_tran <= 0;
+    end else begin
+        ir_addr_tran <= ir_addr_valid && ir_addr_ready;
+    end
+end
+
+reg dr_addr_tran;
+reg dw_data_addr_tran;
+always @(posedge clk) begin
+    if(!rst) begin
+        dr_addr_tran <= 0;
+        dw_data_addr_tran <= 0;
+    end else begin
+        dr_addr_tran <= dr_addr_valid && dr_addr_ready;
+        dw_data_addr_tran <= dw_data_addr_valid && dw_data_addr_ready;
+    end
+end
+
+always @(*) begin
+    if(ir_addr_tran) begin
+        ir_data_valid = r_data_valid;
+        ir_data = r_data;
+    end else begin
+        ir_data_valid = 0;
+        ir_data = 0;
+    end
+    if(dr_addr_tran) begin
+        dr_data_valid = r_data_valid;
+        dr_data = r_data;
+    end else begin
+        dr_data_valid = 0;
+        dr_data = 0;
+    end
+    if(dw_data_addr_tran) begin
+        dw_resp_valid = w_resp_valid;
+        dw_resp = w_resp;
+    end else begin
+        dw_resp_valid = 0;
+        dw_resp = 0;
+    end
+end
+
+assign ir_addr_ready = r_addr_ready;
+assign dw_data_addr_ready = w_data_addr_ready;
+assign dr_addr_ready = r_addr_ready;
+
+fake_memory u_mem (
+    .clk(clk),
+    .rst(rst),
+    .r_addr_valid(r_addr_valid),
+    .r_data_ready(r_data_ready),
+    .w_data_addr_valid(w_data_addr_valid),
+    .r_addr(r_addr),
+    .w_data(w_data),
+    .w_addr(w_addr),
+    .w_resp_ready(w_resp_ready),
+    .w_resp_valid(w_resp_valid),
+    .w_resp(w_resp),
+    .r_addr_ready(r_addr_ready),
+    .r_data_valid(r_data_valid),
+    .w_data_addr_ready(w_data_addr_ready),
+    .r_data(r_data),
+    .w_strobe(dw_strobe)
+);
+endmodule
+
+module fake_memory #(
+    parameter address_width = `FAKE_MEM_ADDR_WIDTH,
+    parameter length = (2**address_width)
+) (
+    input clk,
+    input rst,
+    input r_addr_valid,
+    input r_data_ready,
+    input w_data_addr_valid,
+    input [`BUS_WIDTH-1:0] r_addr,
+    input [`BUS_WIDTH-1:0] w_data,
+    input [`BUS_WIDTH-1:0] w_addr,
+    input w_resp_ready,
+    input [(`BUS_WIDTH/8)-1:0] w_strobe,
+    output reg w_resp_valid,
+    output reg [`BUS_RESP_WIDTH-1:0] w_resp,
+    output reg r_addr_ready,
+    output r_data_valid,
+    output reg w_data_addr_ready,
+    output [`BUS_WIDTH-1:0] r_data
+);
+reg [7:0] memory [length - 1:0];
+`STRING hex_file;
+initial begin
+    $display("%t: %m length: %0d", $time, length);
+    if ($value$plusargs("HEX_FILE=%s", hex_file)) begin
+        $readmemh(hex_file, memory, 0, length - 1);
+    end else begin
+        $display($time, "Error: %m no hex file given. Example: vvp sim.vvp +HEX_FILE=test.hex");
+        $finish;
+    end
+end
+always @(posedge clk)
+    if(!rst) begin
+        r_addr_ready <= 1;
+        w_data_addr_ready <= 1;
+    end
+reg r_data_valid;
+reg [`BUS_WIDTH-1:0] r_data;
+reg read_addr_tran;
+reg read_data_tran;
+reg write_data_addr_tran;
+reg write_resp_tran;
+always @(*) begin
+    read_addr_tran = r_addr_valid && r_addr_ready;
+    read_data_tran = r_data_valid && r_data_ready;
+    write_data_addr_tran = w_data_addr_valid && w_data_addr_ready;
+    write_resp_tran = w_resp_valid && w_resp_ready;
+end
+always @(posedge clk) begin
+    if(!rst) begin
+        r_data <= 0;
+        r_data_valid <= 0;
+    end else if(read_addr_tran) begin
+        r_data <= {
+                memory[r_addr+3],
+                memory[r_addr+2],
+                memory[r_addr+1],
+                memory[r_addr+0]
+        };
+        r_data_valid <= 1;
+    end else if(read_data_tran) begin
+        r_data_valid <= 0;
+    end
+end
+always @(posedge clk) begin
+    if(!rst) begin
+        w_resp <= 0;
+        w_resp_valid <= 0;
+    end else if(write_data_addr_tran) begin
+        memory[w_addr+3] <= w_strobe[3] ? w_data[31:24] : memory[w_addr+3];
+        memory[w_addr+2] <= w_strobe[2] ? w_data[23:16] : memory[w_addr+2];
+        memory[w_addr+1] <= w_strobe[1] ? w_data[15:8]  : memory[w_addr+1];
+        memory[w_addr+0] <= w_strobe[0] ? w_data[7:0]   : memory[w_addr+0];
+        w_resp <= `DATA_WRITE_RESP_OK;
+        w_resp_valid <= 1;
+    end else if(write_resp_tran) begin
+        w_resp_valid <= 0;
+    end
+end
+//always @(negedge clk)
+//    if (read_addr_tran)
+//        $display($time, {msg_prefix, "read addr 0x%0X data 0x%0X"}, r_addr, r_data);
+endmodule

--- a/sim/tests/Icarus_simulation/file_list.txt
+++ b/sim/tests/Icarus_simulation/file_list.txt
@@ -1,0 +1,10 @@
+control_unit.v   
+execution.v      
+testbench.v
+checker_util.v  
+copperv_h.v     
+copperv.v        
+fake_memory.v  
+idecoder.v      
+register_file.v    
+testbench_h.v

--- a/sim/tests/Icarus_simulation/idecoder.v
+++ b/sim/tests/Icarus_simulation/idecoder.v
@@ -1,0 +1,174 @@
+`timescale 1ns/1ps
+`include "copperv_h.v"
+
+module idecoder (
+    input [`INST_WIDTH-1:0] inst,
+    output reg [`IMM_WIDTH-1:0] imm,
+    output reg [`INST_TYPE_WIDTH-1:0] inst_type,
+    output reg [`REG_WIDTH-1:0] rd,
+    output reg [`REG_WIDTH-1:0] rs1,
+    output reg [`REG_WIDTH-1:0] rs2,
+    output reg [`FUNCT_WIDTH-1:0] funct
+);
+reg [`OPCODE_WIDTH-1:0] opcode;
+reg [`FUNCT3_WIDTH-1:0] funct3;
+reg [`FUNCT7_WIDTH-1:0] funct7;
+always @(*) begin
+    inst_type = 0;
+    funct = 0;
+    imm = 0;
+    rs1 = 0;
+    rs2 = 0;
+    rd = 0;
+    funct3 = 0;
+    funct7 = 0;
+    opcode = inst[6:0];
+    case (opcode)
+        `OPCODE_LUI: begin
+            inst_type = `INST_TYPE_IMM;
+            decode_u_type(inst[`INST_WIDTH-1:7]);
+        end
+        `OPCODE_JAL: begin
+            inst_type = `INST_TYPE_JAL;
+            decode_j_type(inst[`INST_WIDTH-1:7]);
+        end
+        `OPCODE_JALR: begin
+            inst_type = `INST_TYPE_JALR;
+            decode_i_type(inst[`INST_WIDTH-1:7]);
+        end
+        `OPCODE_AUIPC: begin
+            inst_type = `INST_TYPE_AUIPC;
+            decode_u_type(inst[`INST_WIDTH-1:7]);
+        end
+        `OPCODE_INT_IMM: begin
+            inst_type = `INST_TYPE_INT_IMM;
+            decode_i_type(inst[`INST_WIDTH-1:7]);
+            case (funct3)
+                3'd0: funct = `FUNCT_ADD;
+                3'd1: funct = `FUNCT_SLL;
+                3'd2: funct = `FUNCT_SLT;
+                3'd3: funct = `FUNCT_SLTU;
+                3'd4: funct = `FUNCT_XOR;
+                3'd5: begin
+                    case(imm[11:5])
+                        7'd0:  funct = `FUNCT_SRL;
+                        7'd32: funct = `FUNCT_SRA;
+                        default: funct = 5'bX;
+                    endcase
+                    imm = `UNSIGNED(imm,32,4,0);
+                end
+                3'd6: funct = `FUNCT_OR;
+                3'd7: funct = `FUNCT_AND;
+                default: funct = 5'bX;
+            endcase
+        end
+        `OPCODE_INT_REG: begin 
+            inst_type = `INST_TYPE_INT_REG;
+            decode_r_type(inst[`INST_WIDTH-1:7]);
+            case ({funct7, funct3})
+                {7'd0,  3'd0}: funct = `FUNCT_ADD;
+                {7'd32, 3'd0}: funct = `FUNCT_SUB;
+                {7'd0,  3'd1}: funct = `FUNCT_SLL;
+                {7'd0,  3'd2}: funct = `FUNCT_SLT;
+                {7'd0,  3'd3}: funct = `FUNCT_SLTU;
+                {7'd0,  3'd4}: funct = `FUNCT_XOR;
+                {7'd0,  3'd5}: funct = `FUNCT_SRL;
+                {7'd32, 3'd5}: funct = `FUNCT_SRA;
+                {7'd0,  3'd6}: funct = `FUNCT_OR;
+                {7'd0,  3'd7}: funct = `FUNCT_AND;
+                default: funct = 5'bX;
+            endcase
+        end
+        `OPCODE_BRANCH: begin
+            inst_type = `INST_TYPE_BRANCH;
+            decode_b_type(inst[`INST_WIDTH-1:7]);
+            case (funct3)
+                3'd0: funct = `FUNCT_EQ;
+                3'd1: funct = `FUNCT_NEQ;
+                3'd4: funct = `FUNCT_LT;
+                3'd5: funct = `FUNCT_GTE;
+                3'd6: funct = `FUNCT_LTU;
+                3'd7: funct = `FUNCT_GTEU;
+                default: funct = 5'bX;
+            endcase
+        end
+        `OPCODE_STORE: begin
+            inst_type = `INST_TYPE_STORE;
+            decode_s_type(inst[`INST_WIDTH-1:7]);
+            case(funct3)
+                3'd0: funct = `FUNCT_MEM_BYTE;
+                3'd1: funct = `FUNCT_MEM_HWORD;
+                3'd2: funct = `FUNCT_MEM_WORD;
+                default: funct = 5'bX;
+            endcase
+        end
+        `OPCODE_LOAD: begin
+            inst_type = `INST_TYPE_LOAD;
+            decode_i_type(inst[`INST_WIDTH-1:7]);
+            case(funct3)
+                3'd0: funct = `FUNCT_MEM_BYTE;
+                3'd1: funct = `FUNCT_MEM_HWORD;
+                3'd2: funct = `FUNCT_MEM_WORD;
+                3'd4: funct = `FUNCT_MEM_BYTEU;
+                3'd5: funct = `FUNCT_MEM_HWORDU;
+                default: funct = 5'bX;
+            endcase
+        end
+        `OPCODE_FENCE: begin
+            inst_type = `INST_TYPE_FENCE;
+        end
+        default: ;
+    endcase
+end
+task decode_u_type;
+    input [`INST_WIDTH-1:7] inst_t;
+    begin
+        imm = {inst_t[31:12], 12'b0};
+        rd = inst_t[11:7];
+    end
+endtask
+task decode_j_type;
+    input [`INST_WIDTH-1:7] inst_t;
+    begin
+        imm = {{12{inst_t[31]}}, inst_t[19:12], inst_t[20], inst_t[30:25], inst_t[24:21], 1'b0};
+        rd = inst_t[11:7];
+    end
+endtask
+task decode_i_type;
+    input [`INST_WIDTH-1:7] inst_t;
+    begin
+        imm = {{21{inst_t[31]}}, inst_t[30:20]};
+        rd = inst_t[11:7];
+        rs1 = inst_t[19:15];
+        funct3 = inst_t[14:12];
+    end
+endtask
+task decode_r_type;
+    input [`INST_WIDTH-1:7] inst_t;
+    begin
+        rs1 = inst_t[19:15];
+        rs2 = inst_t[24:20];
+        rd = inst_t[11:7];
+        funct7 = inst_t[31:25];
+        funct3 = inst_t[14:12];
+    end
+endtask
+task decode_b_type;
+    input [`INST_WIDTH-1:7] inst_t;
+    begin
+        imm = {{20{inst_t[31]}}, inst_t[7], inst_t[30:25], inst_t[11:8], 1'b0};
+        rs1 = inst_t[19:15];
+        rs2 = inst_t[24:20];
+        funct3 = inst_t[14:12];
+    end
+endtask
+task decode_s_type;
+    input [`INST_WIDTH-1:7] inst_t;
+    begin
+        imm = {{21{inst_t[31]}}, inst_t[30:25], inst_t[11:7]};
+        rs1 = inst_t[19:15];
+        rs2 = inst_t[24:20];
+        funct3 = inst_t[14:12];
+    end
+endtask
+endmodule

--- a/sim/tests/Icarus_simulation/register_file.v
+++ b/sim/tests/Icarus_simulation/register_file.v
@@ -1,0 +1,34 @@
+`timescale 1ns/1ps
+`include "copperv_h.v"
+
+module register_file #(
+    parameter reg_length = 2**`REG_WIDTH
+) (
+    input clk,
+    input rst,
+    input rd_en,
+    input rs1_en,
+    input rs2_en,
+    input [`REG_WIDTH-1:0] rd,
+    input [`REG_WIDTH-1:0] rs1,
+    input [`REG_WIDTH-1:0] rs2,
+    input [`DATA_WIDTH-1:0] rd_din,
+    output reg [`DATA_WIDTH-1:0] rs1_dout,
+    output reg [`DATA_WIDTH-1:0] rs2_dout
+);
+reg [`DATA_WIDTH-1:0] mem [reg_length-1:0];
+integer i;
+always @(posedge clk) begin
+    if(!rst) begin
+        for(i = 0; i < reg_length; i = i + 1)
+            mem[i] <= 0;
+    end if(rd_en && rd != 0) begin
+        mem[rd] <= rd_din;
+    end else if(rs1_en && rs2_en) begin
+        rs1_dout <= mem[rs1];
+        rs2_dout <= mem[rs2];
+    end else if(rs1_en) begin
+        rs1_dout <= mem[rs1];
+    end 
+end
+endmodule

--- a/sim/tests/Icarus_simulation/testbench.v
+++ b/sim/tests/Icarus_simulation/testbench.v
@@ -1,0 +1,179 @@
+`timescale 1ns/1ps
+`include "testbench_h.v"
+`include "copperv_h.v"
+
+module tb();
+parameter timeout = `PERIOD*1000000;
+// copperv inputs
+reg clk;
+reg rst;
+wire dr_data_valid;
+wire dr_addr_ready;
+wire dw_data_addr_ready;
+wire dw_resp_valid;
+wire [`BUS_WIDTH-1:0] dr_data;
+wire ir_data_valid;
+wire ir_addr_ready;
+wire [`BUS_WIDTH-1:0] ir_data;
+wire [`BUS_RESP_WIDTH-1:0] dw_resp;
+// copperv outputs
+wire dr_data_ready;
+wire dr_addr_valid;
+wire dw_data_addr_valid;
+wire dw_resp_ready;
+wire [`BUS_WIDTH-1:0] dr_addr;
+wire [`BUS_WIDTH-1:0] dw_data;
+wire [`BUS_WIDTH-1:0] dw_addr;
+wire [(`BUS_WIDTH/8)-1:0] dw_strobe;
+wire ir_data_ready;
+wire ir_addr_valid;
+wire [`BUS_WIDTH-1:0] ir_addr;
+initial begin
+    rst = 0;
+    clk = 0;
+    #(`PERIOD*10);
+    $display($time, ": Reset finished");
+    rst = 1;
+end
+`ifndef DISABLE_TIMEOUT
+initial begin
+    #timeout;
+    $display($time, ": Simulation timeout");
+    test_failed;
+end
+`endif
+always #(`PERIOD/2) clk <= !clk;
+copperv dut (
+    .clk(clk),
+    .rst(rst),
+    .dr_data_valid(dr_data_valid),
+    .dr_addr_ready(dr_addr_ready),
+    .dw_data_addr_ready(dw_data_addr_ready),
+    .dw_resp_valid(dw_resp_valid),
+    .dr_data(dr_data),
+    .ir_data_valid(ir_data_valid),
+    .ir_addr_ready(ir_addr_ready),
+    .ir_data(ir_data),
+    .dw_resp(dw_resp),
+    .dr_data_ready(dr_data_ready),
+    .dr_addr_valid(dr_addr_valid),
+    .dw_data_addr_valid(dw_data_addr_valid),
+    .dw_resp_ready(dw_resp_ready),
+    .dr_addr(dr_addr),
+    .dw_data(dw_data),
+    .dw_addr(dw_addr),
+    .dw_strobe(dw_strobe),
+    .ir_data_ready(ir_data_ready),
+    .ir_addr_valid(ir_addr_valid),
+    .ir_addr(ir_addr)
+);
+sim_crossbar u_xbar (
+    .clk(clk),
+    .rst(rst),
+    .dr_data_valid(dr_data_valid),
+    .dr_addr_ready(dr_addr_ready),
+    .dw_data_addr_ready(dw_data_addr_ready),
+    .dw_resp_valid(dw_resp_valid),
+    .dr_data(dr_data),
+    .ir_data_valid(ir_data_valid),
+    .ir_addr_ready(ir_addr_ready),
+    .ir_data(ir_data),
+    .dw_resp(dw_resp),
+    .dr_data_ready(dr_data_ready),
+    .dr_addr_valid(dr_addr_valid),
+    .dw_data_addr_valid(dw_data_addr_valid),
+    .dw_resp_ready(dw_resp_ready),
+    .dr_addr(dr_addr),
+    .dw_data(dw_data),
+    .dw_addr(dw_addr),
+    .dw_strobe(dw_strobe),
+    .ir_data_ready(ir_data_ready),
+    .ir_addr_valid(ir_addr_valid),
+    .ir_addr(ir_addr)
+);
+//monitor_cpu mon(
+//    .clk(clk),
+//    .rst(rst)
+//);
+//`ifdef ENABLE_CHECKER
+//checker_cpu chk(
+//    .clock(clk),
+//    .reset(rst)
+//);
+`endif
+integer fake_uart_fp;
+`STRING vcd_file;
+initial begin
+    if (!$value$plusargs("VCD_FILE=%s", vcd_file)) begin
+        vcd_file = "tb.vcd";
+    end
+    $dumpfile(vcd_file);
+    $dumpvars(0, tb);
+    fake_uart_fp = $fopen("fake_uart.log","w");
+end
+reg [`DATA_WIDTH-1:0] timer_counter;
+initial timer_counter = 0;
+// Fake IO
+always @(posedge clk) begin
+    // Output
+    if(dw_data_addr_valid && dw_data_addr_ready) begin
+        case (dw_addr)
+            32'h80000000: begin
+                case (dw_data)
+                    32'h01000001: test_passed;
+                    32'h02000001: test_failed;
+                    32'h03000001: unit_test_passed;
+                    default: test_failed;
+                endcase
+            end
+            32'h80000004: begin
+                $fwrite(fake_uart_fp, "%c", dw_data[7:0]);
+                if(dw_data[7:0] == "\n")
+                    $fflush(fake_uart_fp);
+            end
+        endcase
+    end
+    // Input
+    if(dr_addr_valid && dr_addr_ready) begin
+        case (dr_addr)
+            32'h80000008: begin
+                force dr_data = timer_counter;
+                force dr_data_valid = 1;
+                @(posedge clk);
+                release dr_data;
+                release dr_data_valid;
+            end
+        endcase
+    end
+    timer_counter = timer_counter + 1;
+end
+
+task unit_test_passed;
+begin
+    $display($time, ": UNIT TEST PASSED");
+end
+endtask
+task test_passed;
+begin
+    $display($time, ": TEST PASSED");
+    finish_sim;
+end
+endtask
+task test_failed;
+reg [`DATA_WIDTH-1:0] test_id;
+begin
+    test_id = `CPU_INST.regfile.mem[`REG_T3];
+    $display($time, ": TEST FAILED: instruction_id: %0d test_id: %0d", test_id[31:16], test_id[15:0]);
+    finish_sim;
+end
+endtask
+task finish_sim;
+begin
+    //mon.finish_sim;
+    $fwrite(fake_uart_fp, "\n# copperv testbench finished\n");
+    $fclose(fake_uart_fp);  
+    $finish;
+end
+endtask
+endmodule
+

--- a/sim/tests/Icarus_simulation/testbench_h.v
+++ b/sim/tests/Icarus_simulation/testbench_h.v
@@ -1,0 +1,6 @@
+`define STRING              reg [1023:0]
+`define PERIOD              10
+`define TRUE                1
+`define FALSE               0
+`define CPU_INST            tb.dut
+`define FAKE_MEM_ADDR_WIDTH 24

--- a/sim/tests/common/Makefile
+++ b/sim/tests/common/Makefile
@@ -17,6 +17,9 @@ crt0.o: $(COMMON_DIR)/crt0.S
 	$(CC) $(LDFLAGS) -Wl,-T,$(LINKER_SCRIPT),-Bstatic -nostartfiles -ffreestanding $^ -o $@
 	$(SCRIPTS_DIR)/dev_utils.py debug $@
 
+%.hex: %.elf 
+	riscv64-unknown-elf-objcopy -O verilog $< $@ 
+
 .PHONY: clean
 clean:
 	rm -fv *.o *.elf *.debug *.E

--- a/sim/tests/dhrystone/Makefile
+++ b/sim/tests/dhrystone/Makefile
@@ -1,5 +1,6 @@
 
-dhrystone.elf: dhrystone_main.o dhrystone.o syscalls.o | dhrystone.E dhrystone_main.E
+#dhrystone.elf: dhrystone_main.o dhrystone.o syscalls.o | dhrystone.E dhrystone_main.E
+dhrystone.hex: dhrystone_main.o dhrystone.o syscalls.o | dhrystone.E dhrystone_main.E
 
 CFLAGS += -DENTRY_POINT=main
 

--- a/sim/tests/hello_world/Makefile
+++ b/sim/tests/hello_world/Makefile
@@ -1,5 +1,6 @@
 
-hello_world.elf: hello_world.o
+#hello_world.elf: hello_world.o
+hello_world.hex: hello_world.o
 
 CFLAGS += -DENTRY_POINT=main
 

--- a/sim/tests/timer_test/Makefile
+++ b/sim/tests/timer_test/Makefile
@@ -1,5 +1,6 @@
 
-timer_test.elf: timer_test.o
+#timer_test.elf: timer_test.o
+timer_test.hex: timer_test.o
 
 CFLAGS += -DENTRY_POINT=main
 


### PR DESCRIPTION
1. Las modificaciones de los Makefiles se hacen para que los flujos que generan creen archivos .hex
2. El directorio creado para simulaciones en Icarus Verilog (llamado "Icarus_simulation" y ubicado en sim/tests/Icarus_simulation) contiene los archivos necesarios para correr una simulación de "hello_world" en Icarus Verilog. Para lograr que dicha simulación funcionara se debió incluir a archivos del CopperV1.